### PR TITLE
Again: removed unnecessary memcpy, simplified loop condition and post-processing

### DIFF
--- a/sha-256.c
+++ b/sha-256.c
@@ -4,11 +4,7 @@
 #include "sha-256.h"
 
 #define CHUNK_SIZE 64
-#define TOTAL_LEN_LEN 8
-
-/*
- * ABOUT bool: this file does not use bool in order to be as pre-C99 compatible as possible.
- */
+#define INT64_SIZE 8
 
 /*
  * Comments from pseudo-code at https://en.wikipedia.org/wiki/SHA-2 are reproduced here.
@@ -30,14 +26,6 @@ static const uint32_t k[] = {
 	0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
 };
 
-struct buffer_state {
-	const uint8_t * p;
-	size_t len;
-	size_t total_len;
-	int single_one_delivered; /* bool */
-	int total_len_delivered; /* bool */
-};
-
 static inline uint32_t right_rot(uint32_t value, unsigned int count)
 {
 	/*
@@ -45,72 +33,6 @@ static inline uint32_t right_rot(uint32_t value, unsigned int count)
 	 * which is what we need here.
 	 */
 	return value >> count | value << (32 - count);
-}
-
-static void init_buf_state(struct buffer_state * state, const void * input, size_t len)
-{
-	state->p = input;
-	state->len = len;
-	state->total_len = len;
-	state->single_one_delivered = 0;
-	state->total_len_delivered = 0;
-}
-
-/* Return value: bool */
-static int calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state * state)
-{
-	size_t space_in_chunk;
-
-	if (state->total_len_delivered) {
-		return 0;
-	}
-
-	if (state->len >= CHUNK_SIZE) {
-		memcpy(chunk, state->p, CHUNK_SIZE);
-		state->p += CHUNK_SIZE;
-		state->len -= CHUNK_SIZE;
-		return 1;
-	}
-
-	memcpy(chunk, state->p, state->len);
-	chunk += state->len;
-	space_in_chunk = CHUNK_SIZE - state->len;
-	state->p += state->len;
-	state->len = 0;
-
-	/* If we are here, space_in_chunk is one at minimum. */
-	if (!state->single_one_delivered) {
-		*chunk++ = 0x80;
-		space_in_chunk -= 1;
-		state->single_one_delivered = 1;
-	}
-
-	/*
-	 * Now:
-	 * - either there is enough space left for the total length, and we can conclude,
-	 * - or there is too little space left, and we have to pad the rest of this chunk with zeroes.
-	 * In the latter case, we will conclude at the next invokation of this function.
-	 */
-	if (space_in_chunk >= TOTAL_LEN_LEN) {
-		const size_t left = space_in_chunk - TOTAL_LEN_LEN;
-		size_t len = state->total_len;
-		int i;
-		memset(chunk, 0x00, left);
-		chunk += left;
-
-		/* Storing of len * 8 as a big endian 64-bit without overflow. */
-		chunk[7] = (uint8_t) (len << 3);
-		len >>= 5;
-		for (i = 6; i >= 0; i--) {
-			chunk[i] = (uint8_t) len;
-			len >>= 8;
-		}
-		state->total_len_delivered = 1;
-	} else {
-		memset(chunk, 0x00, space_in_chunk);
-	}
-
-	return 1;
 }
 
 /*
@@ -132,48 +54,82 @@ void calc_sha_256(uint8_t hash[32], const void * input, size_t len)
 	 *     the first word of the input message "abc" after padding is 0x61626380
 	 */
 
+	unsigned i, j;
+
+	/* Storing of len * 8 as a big endian 64-bit without overflow. */
+	uint8_t total_len[INT64_SIZE];
+	total_len[INT64_SIZE - 1] = (uint8_t) (len << 3);
+	size_t lc = len >> 5;
+	for (i = 1; i < INT64_SIZE; i++) {
+		total_len[INT64_SIZE - 1 - i] = (uint8_t) lc;
+		lc >>= 8;
+	}
+
 	/*
 	 * Initialize hash values:
 	 * (first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19):
 	 */
 	uint32_t h[] = { 0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 };
-	unsigned i, j;
 
-	/* 512-bit chunks is what we will operate on. */
-	uint8_t chunk[64];
+	/* Reserve a chunk for Pre-processing */
+	uint8_t processed_chunk[CHUNK_SIZE];
 
-	struct buffer_state state;
+	/* Process the message and additional appended bytes in successive 512-bit chunks */
+	const uint8_t *input_end = (uint8_t *) input + len;
+	for (const uint8_t *chunk = input; chunk < input_end + 1 + INT64_SIZE; chunk += CHUNK_SIZE) {
+		const uint8_t *p;
 
-	init_buf_state(&state, input, len);
+		if (chunk + CHUNK_SIZE <= input_end) {
+			/* Normal processing */
+			p = chunk;
+		} else {
+			/*
+			 * Pre-processing, append the following to the input:
+			 * - A single '1' bit
+			 * - Padding with '0' bits so that all chunks are 512-bit
+			 * - The 64-bit message length at the end
+			 */
+			memset(processed_chunk, 0, CHUNK_SIZE);
+			if (chunk == input_end) {
+				/* Input ended exactly at the end of previous chunk, start this chunk with the single '1' bit */
+				processed_chunk[0] = 0x80;
+			} else if (chunk < input_end) {
+				/* Copy the last bytes of input to this chunk, followed by the single '1' bit */
+				memcpy(processed_chunk, chunk, input_end - chunk);
+				processed_chunk[input_end - chunk] = 0x80;
+			}
+			/* Add the 64-bit message length if it fits in this chunk, otherwise in the next chunk */
+			if (chunk + CHUNK_SIZE >= input_end + 1 + INT64_SIZE)
+				memcpy(&processed_chunk[CHUNK_SIZE - INT64_SIZE], total_len, INT64_SIZE);
 
-	while (calc_chunk(chunk, &state)) {
+			p = processed_chunk;
+		}
+
 		uint32_t ah[8];
-
-		const uint8_t *p = chunk;
 
 		/* Initialize working variables to current hash value: */
 		for (i = 0; i < 8; i++)
 			ah[i] = h[i];
 
-                /*
-                 * The w-array is really w[64], but since we only need
-                 * 16 of them at a time, we save stack by calculating
-                 * 16 at a time.
-                 *
-                 * This optimization was not there initially and the
-                 * rest of the comments about w[64] are kept in their
-                 * initial state.
-                 */
+		/*
+		 * The w-array is really w[64], but since we only need
+		 * 16 of them at a time, we save stack by calculating
+		 * 16 at a time.
+		 *
+		 * This optimization was not there initially and the
+		 * rest of the comments about w[64] are kept in their
+		 * initial state.
+		 */
 
-                /*
-                 * create a 64-entry message schedule array w[0..63] of 32-bit
-                 * words (The initial values in w[0..63] don't matter, so many
-                 * implementations zero them here) copy chunk into first 16
-                 * words w[0..15] of the message schedule array
-                 */
-                uint32_t w[16];
+		/*
+		 * create a 64-entry message schedule array w[0..63] of 32-bit
+		 * words (The initial values in w[0..63] don't matter, so many
+		 * implementations zero them here) copy chunk into first 16
+		 * words w[0..15] of the message schedule array
+		 */
+		uint32_t w[16];
 
-                /* Compression function main loop: */
+		/* Compression function main loop: */
 		for (i = 0; i < 4; i++) {
 			for (j = 0; j < 16; j++) {
 				if (i == 0) {

--- a/sha-256.c
+++ b/sha-256.c
@@ -59,7 +59,7 @@ void calc_sha_256(uint8_t hash[32], const void * input, size_t len)
 	/* The length of the original message in bits as a 64-bit big-endian integer */
 	uint8_t total_len[INT64_SIZE];
 	for (i = 0; i < INT64_SIZE; i++)
-		total_len[i] = (uint8_t) ((len << 3) >> ((INT64_SIZE - i - 1) * 8));
+		total_len[i] = (uint8_t) (((uint64_t) len << 3) >> ((INT64_SIZE - i - 1) * 8));
 
 	/*
 	 * Initialize hash values:
@@ -107,29 +107,27 @@ void calc_sha_256(uint8_t hash[32], const void * input, size_t len)
 		for (i = 0; i < 8; i++)
 			ah[i] = h[i];
 
+		/*
+		 * The w-array is really w[64], but since we only need
+		 * 16 of them at a time, we save stack by calculating
+		 * 16 at a time.
+		 *
+		 * This optimization was not there initially and the
+		 * rest of the comments about w[64] are kept in their
+		 * initial state.
+		 */
+		/*
+		 * create a 64-entry message schedule array w[0..63] of 32-bit words
+		 * (The initial values in w[0..63] don't matter, so many implementations zero them here)
+		 */
+		uint32_t w[16];
+
 		/* Compression function main loop: */
 		for (i = 0; i < 4; i++) {
-			/*
-			 * The w-array is really w[64], but since we only need
-			 * 16 of them at a time, we save stack by calculating
-			 * 16 at a time.
-			 *
-			 * This optimization was not there initially and the
-			 * rest of the comments about w[64] are kept in their
-			 * initial state.
-			 */
-
-			/*
-			 * create a 64-entry message schedule array w[0..63] of 32-bit words
-			 * (The initial values in w[0..63] don't matter, so many implementations zero them here)
-			 * copy chunk into first 16 words w[0..15] of the message schedule array
-			 */
-			uint32_t w[16];
-
 			for (j = 0; j < 16; j++) {
 				if (i == 0) {
-					w[j] = (uint32_t) p[0] << 24 | (uint32_t) p[1] << 16 |
-						(uint32_t) p[2] << 8 | (uint32_t) p[3];
+					/* Copy chunk into first 16 words w[0..15] of the message schedule array */
+					w[j] = (uint32_t) p[0] << 24 | (uint32_t) p[1] << 16 | (uint32_t) p[2] << 8 | (uint32_t) p[3];
 					p += 4;
 				} else {
 					/* Extend the first 16 words into the remaining 48 words w[16..63] of the message schedule array: */


### PR DESCRIPTION
Hopefully the third time is the charm. Same changes as #6, but now with the original "Storing of len * 8" restored. The loop is inverted though, because `i >= 0` will not work for unsigned.

As a side note, it is so much easier to just memcpy the result of `htobe64((uint64_t) len * 8)`. But I understand that is beside the point of this implementation.
